### PR TITLE
XCode 10.2 compatibility

### DIFF
--- a/Operations.podspec
+++ b/Operations.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name              = "Operations"
-  s.version           = "5.0.0"
+  s.version           = "5.0.1"
   s.summary           = "Powerful NSOperation subclasses in Swift."
   s.description       = <<-DESC
   

--- a/Operations.podspec.json
+++ b/Operations.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "Operations",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "summary": "Powerful NSOperation subclasses in Swift.",
   "description": "A Swift framework inspired by Apple's WWDC 2015\nsession Advanced NSOperations: https://developer.apple.com/videos/wwdc/2015/?id=226",
   "homepage": "https://github.com/cezarywojcik/Operations",
@@ -10,7 +10,7 @@
   },
   "source": {
     "git": "https://github.com/cezarywojcik/Operations.git",
-    "tag": "5.0.0"
+    "tag": "5.0.1"
   },
   "module_name": "Operations",
   "documentation_url": "http://docs.danthorpe.me/operations/2.10.0/index.html",

--- a/Sources/Core/Shared/Condition.swift
+++ b/Sources/Core/Shared/Condition.swift
@@ -17,7 +17,7 @@ public protocol ConditionType {
 
 internal extension ConditionType {
 
-    internal var category: String {
+    var category: String {
         return "\(type(of: self))"
     }
 }

--- a/Sources/Core/Shared/GroupOperation.swift
+++ b/Sources/Core/Shared/GroupOperation.swift
@@ -29,7 +29,7 @@ open class GroupOperation: AdvancedOperation, OperationQueueDelegate {
         var attemptedRecovery: ErrorsByOperation = [:]
 
         var previousAttempts: [Error] {
-            return Array(FlattenCollection(attemptedRecovery.values))
+            return attemptedRecovery.values.flatMap({ $0 })
         }
 
         var all: [Error] {


### PR DESCRIPTION
Two changes:
1. change `FlattenCollection` to `flatMap` since in XCode 10.2+, FlattenCollection is typealias of FlattenSequence (https://developer.apple.com/documentation/swift/flattencollection?changes=latest_minor) and in the previous version FlattenCollection is a struct (https://swiftdoc.org/v4.2/type/flattencollection/)
2. kill warning of redundant "internal" 